### PR TITLE
Changed parent POM version to 2.13.

### DIFF
--- a/moskito-central-server/moskito-central-dime-server/pom.xml
+++ b/moskito-central-server/moskito-central-dime-server/pom.xml
@@ -6,7 +6,6 @@
 		<version>1.1.5-SNAPSHOT</version>
 	</parent>
 	<artifactId>moskito-central-dime-server</artifactId>
-	<groupId>org.moskito</groupId>
 	<version>1.1.5-SNAPSHOT</version>
 
 	<dependencies>
@@ -73,6 +72,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
 				<configuration>
 					<archive>
 						<manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.anotheria</groupId>
 		<artifactId>parent</artifactId>
-		<version>2.7</version>
+		<version>2.13</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Changed version of the maven-assembly-plugin to 3.3.0 to fix "Execution make-assembly of goal org.apache.maven.plugins:maven-assembly-plugin:2.2-beta-5:single failed.: NullPointerException" issue.